### PR TITLE
Fix potential cause of segfaults in smallfry

### DIFF
--- a/src/smallfry.c
+++ b/src/smallfry.c
@@ -72,7 +72,7 @@ static double aae_factor(uint8_t *orig, uint8_t *cmp, int orig_stride,
     new = cmp;
 
     for (i = 0; i < height; i++) {
-        for (j = 7; j < width - 1; j += 8) {
+        for (j = 7; j < width - 2; j += 8) {
             double calc;
 
             cnt++;


### PR DESCRIPTION
I occasionally run into segfaults when using `jpeg-recompress -m smallfry` on some images.

## Explanation of the fix
This fix is required because in line 81 there is `DVAL(j + 2)` which is transformed into `abs(old[j+2] - new[j+2])`.
On the last iteration in this loop `j` will be equal `width - 2`, meaning we are accessing `abs(old[width] - new[width])`, 
which in case of the last row of an image is beyond what was allocated.
